### PR TITLE
Support viewing secrets with vaultpath

### DIFF
--- a/src/js/components/Resources/NewResourceForm.js
+++ b/src/js/components/Resources/NewResourceForm.js
@@ -132,10 +132,7 @@ class NewResourceForm extends Component {
       }
 
       if (Object.keys(currentSecrets).length > 0) {
-        form.secrets = {}
-        Object.keys(currentSecrets).forEach(k => {
-          form.secrets[k] = { value: currentSecrets[k] }
-        })
+        form.secrets = currentSecrets;
       }
 
       if (Object.keys(currentFiles).length > 0) {
@@ -186,6 +183,41 @@ class NewResourceForm extends Component {
       property.required === true ? " *" : ""
     }`
     const { properties, currentSecrets, currentFiles } = this.state
+
+    const SecretInput = ({ value }) =>
+      <MaterialTextBox
+          field={key}
+          errorText={
+            this.displayValidationError(
+                currentSecrets[key],
+                property.required
+            )
+                ? "Required secret "
+                : null
+          }
+          value={value}
+          label={label}
+          onChange={(field, newValue) =>
+              this.handleChange(field, { value: newValue }, "currentSecrets")
+          }
+      />
+
+    const VaultPathInput = ({ value }) =>
+      <MaterialTextArea
+          field={key}
+          errorText={
+            this.displayValidationError(properties[key], property.required)
+                ? "Required property "
+                : null
+          }
+          value={value}
+          label={`${label} (Vault Path)`}
+          onChange={(field, newValue) =>
+              this.handleChange(field, { vaultpath: newValue }, "currentSecrets")
+          }
+      />
+
+    const currentSecret = this.state.currentSecrets[key]
 
     switch (property.type) {
       case "textbox":
@@ -238,25 +270,20 @@ class NewResourceForm extends Component {
           />
         )
       case "secret":
-        return (
-          <MaterialTextBox
-            key={key}
-            field={key}
-            errorText={
-              this.displayValidationError(
-                currentSecrets[key],
-                property.required
-              )
-                ? "Required secret "
-                : null
-            }
-            value={this.state.currentSecrets[key]}
-            label={label}
-            onChange={(field, newValue) =>
-              this.handleChange(field, newValue, "currentSecrets")
-            }
-          />
-        )
+      case "vaultPath":
+        if (currentSecret == null) {
+          if (key == "vaultPath") {
+            return <VaultPathInput key={key} value="" />
+          } else {
+            return <SecretInput key={key} value="" />
+          }
+        } else if (currentSecret.vaultpath != null) {
+          return <VaultPathInput key={key} value={currentSecret.vaultpath} />
+        } else if (currentSecret.value != null) {
+          return <SecretInput key={key} value={currentSecret.value} />
+        } else {
+          return <div>Error: Unknown secret format. (Bug in fasit or fasit-frontend)</div>
+        }
       case "file":
         return (
           <div
@@ -299,6 +326,9 @@ class NewResourceForm extends Component {
         )
         break
       default:
+        return (
+            <div>Unknown resource type {property.type}</div>
+        )
     }
   }
 

--- a/src/js/components/Resources/Resource.js
+++ b/src/js/components/Resources/Resource.js
@@ -33,6 +33,12 @@ const initialState = {
   comment: ""
 }
 
+function vaultUrl(vaultPath) {
+  const baseUrl = 'https://vault.adeo.no/ui/vault/secrets/';
+  const replaced = vaultPath.replace(/^([\w-]+)\/data\/(.*)\/[\w-]+$/, '$1/show/$2');
+  return baseUrl + replaced;
+}
+
 class Resource extends Component {
   constructor(props) {
     super(props)
@@ -181,32 +187,53 @@ class Resource extends Component {
             secondaryText={propertyName}
           />
         )
+      case "vaultPath":
       case "secret":
-        const secretText = this.props.currentSecrets[key]
-          ? this.props.currentSecrets[key]
-          : "No secret stored for this revision"
+        const secret = resource.secrets[key]
+        if (secret.vaultpath != null) {
+          return (
+            <ListItem
+                key={key}
+                style={{ paddingTop: "0px", paddingBottom: "14px" }}
+                disabled={true}
+                className="text-overflow"
+                primaryText={
+                  <span>
+                  <a href={vaultUrl(secret.vaultpath)}>
+                    {secret.vaultpath}
+                  </a>
+                  </span>
+                }
+                secondaryText={`${propertyName} (Vault Path)`}
+            />
+          )
+        } else {
+          const secretText = this.props.currentSecrets[key]
+              ? this.props.currentSecrets[key].value
+              : "No secret stored for this revision"
 
-        return (
-          <ListItem
-            key={key}
-            style={{ paddingTop: "0px", paddingBottom: "14px" }}
-            disabled={true}
-            className="text-overflow"
-            primaryText={
-              <div>
-                {secretVisible ? secretText : "*********"}
-                <SecretToggle
-                  user={user}
-                  accesscontrol={resource.accesscontrol}
-                  secretVisible={secretVisible}
-                  toggleHandler={() => this.toggleDisplaySecret()}
-                  dispatch={dispatch}
-                />
-              </div>
-            }
-            secondaryText={propertyName}
-          />
-        )
+          return (
+            <ListItem
+              key={key}
+              style={{ paddingTop: "0px", paddingBottom: "14px" }}
+              disabled={true}
+              className="text-overflow"
+              primaryText={
+                <div>
+                  {secretVisible ? secretText : "*********"}
+                  <SecretToggle
+                    user={user}
+                    accesscontrol={resource.accesscontrol}
+                    secretVisible={secretVisible}
+                    toggleHandler={() => this.toggleDisplaySecret()}
+                    dispatch={dispatch}
+                  />
+                </div>
+              }
+              secondaryText={propertyName}
+            />
+          )
+        }
       case "file":
         return (
           <ListItem

--- a/src/js/sagas/resource_fasit.js
+++ b/src/js/sagas/resource_fasit.js
@@ -58,9 +58,17 @@ export function* fetchFasitResourceSecret() {
 
             let secrets = {}
             for (let i = 0; i < keys.length; i++) {
-                let key = keys[i]
-                const secret = yield call(fetchUrl, secretRefs[key].ref)
-                secrets[key] = secret
+                const key = keys[i]
+                if (secretRefs[key].vaultpath != null) {
+                    secrets[key] = secretRefs[key]
+                } else {
+                    const secret = yield call(fetchUrl, secretRefs[key].ref)
+                    secrets[key] = {
+                        ...secretRefs[key],
+                        value: secret
+                    }
+                }
+
                 yield put({ type: RESOURCE_FASIT_SECRET_RECEIVED, secrets })
             }
         }

--- a/src/js/utils/resourceTypes.js
+++ b/src/js/utils/resourceTypes.js
@@ -54,8 +54,8 @@ export const resourceTypes = {
       textbox("onsHosts", "ONS Hosts (Oracle DataGuard only)", false),
       textbox("oemEndpoint", "OEM endpoint (Oracle PDB only)", false),
       textbox("username"),
-      // secret("password"),
-      vaultPath('password')
+      secret("password")
+      // vaultPath('password')
     ]
   },
   MSSQLDataSource: {

--- a/src/js/utils/resourceTypes.js
+++ b/src/js/utils/resourceTypes.js
@@ -54,7 +54,8 @@ export const resourceTypes = {
       textbox("onsHosts", "ONS Hosts (Oracle DataGuard only)", false),
       textbox("oemEndpoint", "OEM endpoint (Oracle PDB only)", false),
       textbox("username"),
-      secret("password")
+      // secret("password"),
+      vaultPath('password')
     ]
   },
   MSSQLDataSource: {
@@ -361,4 +362,13 @@ function file(name, displayName, required = false) {
     displayName || capitalize(name),
     required
   )
+}
+
+function vaultPath(name) {
+  return new ResourceTypeProperty(
+      "vaultPath",
+      name,
+      capitalize(name),
+      true
+  );
 }

--- a/test/mockend/resourcesMock.js
+++ b/test/mockend/resourcesMock.js
@@ -474,6 +474,41 @@ const resources = [
   },
   {
     type: "datasource",
+    alias: "vaultTestDataSource",
+    scope: {
+      environmentclass: "q",
+      zone: "sbs",
+      application: "yrkesveileder2"
+    },
+    properties: {
+      url:
+          "jdbc:oracle:thin:@(DESCRIPTION=(FAILOVER=on)(CONNECT_TIMEOUT= 15)(RETRY_COUNT=20)(RETRY_DELAY=3)(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=databaseserver.com)(PORT=1521))(ADDRESS=(PROTOCOL=TCP)(HOST=databaserserver2.com)(PORT=1522)))(CONNECT_DATA=(SERVICE_NAME=testdb_ha)))",
+      username: "db_user2"
+    },
+    secrets: {
+      password: {
+        vaultpath: "oracle/data/dev/creds/inst_q8-user/password",
+        ref: "http://localhost:6969/mockapi/secrets/771398"
+      }
+    },
+    files: {},
+    dodgy: false,
+    id: 44,
+    created: "2014-12-03T13:40:30.974",
+    updated: "2014-12-03T13:40:30.974",
+    lifecycle: {},
+    accesscontrol: {
+      environmentclass: "q",
+      adgroups: []
+    },
+    usedbyapplications: [],
+    links: {
+      self: "http://localhost:9696/resources/24",
+      revisions: "http://localhost:9696/resources/24/revisions"
+    }
+  },
+  {
+    type: "datasource",
     alias: "skikkelig.lang.url.til.datasource",
     scope: {
       environmentclass: "q",


### PR DESCRIPTION
If a secret has a vault path, show the reference to the URL in Vault
instead of the value of the secret.