### PR TITLE
fix(search): handle both casings of detailedInfo

### DIFF
--- a/src/js/components/Search/Search.jsx
+++ b/src/js/components/Search/Search.jsx
@@ -52,13 +52,13 @@ function Search({ dispatch, match, location, searchResults, searchQuery }) {
         let avatar = icons[searchResult.type]
         let subtitle = capitalize(searchResult.type)
 
-        const detailedInfo = searchResult.detailedinfo
+        const detailedInfo = searchResult.detailedinfo || searchResult.detailedInfo || {}
         const hasDetailedInfo = Object.keys(detailedInfo).length > 0
 
         switch (searchResult.type) {
             case RESOURCE:
                 title = `${getResourceTypeName(detailedInfo.type)} ${searchResult.name}`
-                subtitle = `${subtitle} ${searchResult.detailedinfo.scope}`
+                subtitle = `${subtitle} ${detailedInfo.scope}`
                 avatar = resourceTypeIcon(detailedInfo.type)
                 break
             case CLUSTER:
@@ -66,7 +66,7 @@ function Search({ dispatch, match, location, searchResults, searchQuery }) {
                 break
             case INSTANCE:
             case APPCONFIG:
-                subtitle = capitalize(searchResult.detailedinfo.environment)
+                subtitle = capitalize(detailedInfo.environment || searchResult.type)
                 break
         }
 
@@ -102,9 +102,9 @@ function Search({ dispatch, match, location, searchResults, searchQuery }) {
                         </Table>
                     </CardContent>}
                     {searchResult.type === RESOURCE
-                        && searchResult.detailedinfo.type.toLowerCase() === 'deploymentmanager'
+                        && detailedInfo.type && detailedInfo.type.toLowerCase() === 'deploymentmanager'
                         && <CardActions style={{ paddingTop: '0px' }}>
-                            <WebsphereManagementConsole hostname={searchResult.detailedinfo.hostname} />)
+                            <WebsphereManagementConsole hostname={detailedInfo.hostname} />)
                     </CardActions>}
                 </Card>
             </div>)

--- a/test/mockend/searchMock.js
+++ b/test/mockend/searchMock.js
@@ -134,6 +134,22 @@ const search = [
             "type": "applicationproperties"
         }
     },
+        {
+        "id": 1791124,
+        "name": "coolproperties.properties",
+        "link": "https://fasit.adeo.no/api/v2/resources/1791124",
+        "type": "resource",
+        "info": "ApplicationProperties | p/SBS/-/-",
+        "lastChange": 1474521832237,
+        "lifecycle": {
+            "status": null
+        },
+        "detailedInfo": {
+            "scope": "p/SBS/-/-",
+            "applicationProperties": "fileList=[file1.properties, file2.properties, file3.properties]",
+            "type": "applicationproperties"
+        }
+    },
     {
         "id": 830929,
         "name": "BidragDataSource",


### PR DESCRIPTION
Handle both camelCase and all lowercase of the search API

 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>